### PR TITLE
Use 'old' pyramid_swagger configurations for request/response validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ matrix:
     python: "3.6"
 
   - env: TOXENV=docs
-  - env: TOXENV=pep8
+  - env: TOXENV=pre-commit
 
 install:
 - "pip install tox coveralls"
 script:
-- tox -e $TOXENV
+- tox
 after_success:
 - coveralls
 # Faster runs on container based infrastucture

--- a/pyramid_mock_server/__init__.py
+++ b/pyramid_mock_server/__init__.py
@@ -33,8 +33,9 @@ def includeme(config):
             config.include('pyramid_swagger')
         except ImportError:  # pragma: no cover
             print(
-                '`pyramid_mock_server.get_resources_from_pyramid_swagger_2_0_schema` requires pyramid_swagger '
-                'dependency. Hint: install pyramid-mock-server with the `pyramid-swagger` extra dependency'
+                '`pyramid_mock_server.get_resources_from_pyramid_swagger_2_0_schema` requires '
+                'pyramid_swagger dependency. Hint: install pyramid-mock-server with the '
+                '`pyramid-swagger` extra dependency',
             )
             six.reraise(*sys.exc_info())
 

--- a/pyramid_mock_server/enhance_swagger_spec.py
+++ b/pyramid_mock_server/enhance_swagger_spec.py
@@ -26,8 +26,8 @@ def _mock_server_app(swagger_spec_path, mock_responses_path, custom_view_package
         'pyramid_swagger.schema_directory': os.path.abspath(os.path.dirname(swagger_spec_path)),
         'pyramid_swagger.schema_file': os.path.basename(swagger_spec_path),
         'pyramid_swagger.swagger_versions': ['2.0'],
-        'bravado_core.validate_requests': False,
-        'bravado_core.validate_responses': True,
+        'pyramid_swagger.enable_request_validation': False,
+        'pyramid_swagger.enable_response_validation': True,
 
         # pyramid_mock_server config
         'pyramid_mock_server.mock_responses_path': mock_responses_path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,8 +46,8 @@ def _create_application(
         # pyramid_swagger config
         'pyramid_swagger.schema_directory': schema_directory,
         'pyramid_swagger.swagger_versions': ['2.0'],
-        'bravado_core.validate_requests': True,
-        'bravado_core.validate_responses': True,
+        'pyramid_swagger.enable_request_validation': True,
+        'pyramid_swagger.enable_response_validation': True,
 
         # pyramid_mock_server config
         'pyramid_mock_server.custom_view_packages': packages,

--- a/tests/view_maker_test.py
+++ b/tests/view_maker_test.py
@@ -5,9 +5,9 @@ from __future__ import unicode_literals
 import sys
 
 import pytest
-from .conftest import create_test_app
 from pyramid.response import Response
 
+from .conftest import create_test_app
 from pyramid_mock_server.view_maker import register_custom_view
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,14 +12,6 @@ commands =
     coverage run --branch --source=pyramid_mock_server/ -m py.test -v --capture=no --strict {posargs}
     coverage report -m --fail-under 100
 
-[testenv:pep8]
-basepython = python2.7
-deps =
-    flake8
-commands =
-    flake8 pyramid_mock_server
-    flake8 tests
-
 [flake8]
 basepython = python2.7
 exclude = .tox,*.egg
@@ -34,4 +26,4 @@ commands = sphinx-build -b html -d build/doctrees source build/html
 
 [testenv:pre-commit]
 deps = pre-commit>=0.12.0
-commands = pre-commit {posargs}
+commands = pre-commit {posargs:run --all-files}


### PR DESCRIPTION
pyramid_swagger suggests the usage of `bravado_core.validate_requests` instead of `pyramid_swagger.enable_request_validation` but internally does still rely on the _deprecated_  syntax.

I will try to provide a PR for the `pyramid_swagger` project soon-ish, but as for now the provided tool does not work as expected in case of request validation errors.

NOTE: validation errors are acceptable in case of spec enhancing process as we are not adding all the parameters needed for the request (ie. the body is missing or required parameters are not passed at all)