### PR TITLE
Validating the specs should not alter the final output

### DIFF
--- a/pyramid_mock_server/enhance_swagger_spec.py
+++ b/pyramid_mock_server/enhance_swagger_spec.py
@@ -113,7 +113,8 @@ def main(argv=None):
 
     if not args.ignore_validation:
         # If specs are invalid this is going to throw an exception
-        Spec.from_dict(flattened_enhanced_specs)
+        # NOTE: Spec.from_dict alters the input specs, so we need to copy them
+        Spec.from_dict(deepcopy(flattened_enhanced_specs))
 
     if not args.output:
         print(json.dumps(flattened_enhanced_specs, sort_keys=True, indent=2))

--- a/tests/enhance_swagger_spec_test.py
+++ b/tests/enhance_swagger_spec_test.py
@@ -60,14 +60,20 @@ def test_enhance_specs_save_on_file(tmpdir, expected_enhances_specs):
 
 @pytest.mark.parametrize('ignore_validation', [True, False])
 @mock.patch('pyramid_mock_server.enhance_swagger_spec.Spec', autospec=True)
-def test_enhance_specs_validation(mock_Spec, capsys, ignore_validation):
+def test_enhance_specs_validation(mock_Spec, capsys, ignore_validation, expected_enhances_specs):
     assert main((['--ignore-validation'] if ignore_validation else []) + [
+        '-c',
+        'tests/view_maker_test_files/custom_views',
+        '--',
         'tests/view_maker_test_files/swagger.json',
         'tests/view_maker_test_files/responses',
     ]) == 0
+
     stdout, _ = capsys.readouterr()
 
     if ignore_validation:
         assert not mock_Spec.from_dict.called
     else:
         mock_Spec.from_dict.assert_called_once_with(json.loads(stdout))
+
+    assert expected_enhances_specs == json.loads(stdout)

--- a/tests/view_maker_test_files/enhanced_swagger.json
+++ b/tests/view_maker_test_files/enhanced_swagger.json
@@ -29,10 +29,7 @@
               }
             },
             "schema": {
-              "$ref": "#/definitions/TestResponse",
-              "x-scope": [
-                ""
-              ]
+              "$ref": "#/definitions/TestResponse"
             }
           }
         }
@@ -49,10 +46,7 @@
               }
             },
             "schema": {
-              "$ref": "#/definitions/TestResponse",
-              "x-scope": [
-                ""
-              ]
+              "$ref": "#/definitions/TestResponse"
             }
           }
         }
@@ -83,10 +77,7 @@
               }
             },
             "schema": {
-              "$ref": "#/definitions/TestResponse",
-              "x-scope": [
-                ""
-              ]
+              "$ref": "#/definitions/TestResponse"
             }
           }
         }
@@ -98,10 +89,7 @@
           "200": {
             "description": "Foo bar response",
             "schema": {
-              "$ref": "#/definitions/TestResponse",
-              "x-scope": [
-                ""
-              ]
+              "$ref": "#/definitions/TestResponse"
             }
           }
         }
@@ -113,10 +101,7 @@
           "default": {
             "description": "Foo response",
             "schema": {
-              "$ref": "#/definitions/TestResponse",
-              "x-scope": [
-                ""
-              ]
+              "$ref": "#/definitions/TestResponse"
             }
           }
         },
@@ -144,10 +129,7 @@
               }
             },
             "schema": {
-              "$ref": "#/definitions/TestResponse",
-              "x-scope": [
-                ""
-              ]
+              "$ref": "#/definitions/TestResponse"
             }
           }
         },
@@ -171,10 +153,7 @@
           "200": {
             "description": "The response is generated via a custom view",
             "schema": {
-              "$ref": "#/definitions/TestResponse",
-              "x-scope": [
-                ""
-              ]
+              "$ref": "#/definitions/TestResponse"
             },
             "examples": {
               "application/json": {


### PR DESCRIPTION
Due to an internal issue I did noticed that the changes of the previous PR had a _minor_ related to the fact that bravado-core swagger validation alters the input object.

Running the tool with and without validation leads to two different outputs.
In order to prevent such behaviour I'm ensuring that  a _deep copy_  is passed for validation and a test ensures that regardless the value of `--ignore-validation` the output will be stable